### PR TITLE
Change properties from being late initialized to empty maps

### DIFF
--- a/lib/src/Features/feature_data_source.dart
+++ b/lib/src/Features/feature_data_source.dart
@@ -18,8 +18,8 @@ class FeatureDataSource {
     return model;
   }
 
-  late FeaturedDataModel model;
-  late Map<String, dynamic> data;
+  FeaturedDataModel model = FeaturedDataModel(features: {});
+  Map<String, dynamic> data = {};
 
   /// Assign response to local variable [data]
   void onSuccess(response) {
@@ -28,6 +28,8 @@ class FeatureDataSource {
 
   /// Initialize [model] from the [data]
   void setUpModel() {
-    model = FeaturedDataModel.fromJson(data);
+    if (data.isNotEmpty) {
+      model = FeaturedDataModel.fromJson(data);
+    }
   }
 }


### PR DESCRIPTION
When the device has no internet connection we are still trying to use
these properties, but they have not been initialized. We can fix this
by initializing them as empty maps to prevent a LateInitializationError.
Then we check .isNotEmpty when setting the model.

<!-- ps-id: 50049325-59c5-4fcc-a680-d59b3d6aac3f -->